### PR TITLE
Fix: getting lr from configuration file

### DIFF
--- a/code/tools/optimizer_factory.py
+++ b/code/tools/optimizer_factory.py
@@ -14,10 +14,10 @@ class Optimizer_Factory():
                    'clipnorm=10'.format(cf.learning_rate))
 
         elif cf.optimizer == 'adam':
-            opt = Adam(lr=1E-3, beta_1=0.9, beta_2=0.999, epsilon=1e-08)
+            opt = Adam(lr=cf.learning_rate, beta_1=0.9, beta_2=0.999, epsilon=1e-08)
 
         elif cf.optimizer == 'sgd':
-            opt = SGD(lr=1E-3, momentum=0.9, nesterov=True)
+            opt = SGD(lr=cf.learning_rate, momentum=0.9, nesterov=True)
 
         else:
             raise ValueError("Unknown optimizer. Valid optimizer arguments are: 'rmsprop', 'adam' and 'sgd'.")


### PR DESCRIPTION
I saw that learning rates from the configuration files were not passed to Adam or SGD optimizers and I have changed it in the code.
