### PR TITLE
Fix: Cropping is not being applied to test images

### DIFF
--- a/code/tools/dataset_generators.py
+++ b/code/tools/dataset_generators.py
@@ -132,6 +132,7 @@ class Dataset_Generators():
                                    samplewise_std_normalization=cf.norm_samplewise_std_normalization,
                                    gcn=cf.norm_gcn,
                                    zca_whitening=cf.norm_zca_whitening,
+                                   crop_size=cf.crop_size_test,
                                    dim_ordering='th' if cf.model_name == 'yolo' else 'default',
                                    class_mode=cf.dataset.class_mode)
         test_gen = dg_ts.flow_from_directory(directory=cf.dataset.path_test_img,


### PR DESCRIPTION
The configuration variable `crop_size_test` was not being used when creating the `ImageDataGenerator` for the test set. Therefore, the code would crash if the crop size is different from the resize size.

`ValueError: could not broadcast input array from shape (256,256,3) into shape (2
24,224,3)
`