### PR TITLE
Fix transfer learning

### DIFF
--- a/code/config/configuration.py
+++ b/code/config/configuration.py
@@ -79,10 +79,19 @@ class Configuration():
         elif cf.resize_test is not None: cf.target_size_test = cf.resize_test
         else: cf.target_size_test = cf.dataset.img_shape
 
-        # Get weights file name
+        # Get training weights file name
         path, _ = os.path.split(cf.weights_file)
         if path == '':
             cf.weights_file = os.path.join(cf.savepath, cf.weights_file)
+
+        # Get testing weights file name
+        try:
+            path_test, _ = os.path.split(cf.weights_test_file)
+            if path_test == '':
+                cf.weights_test_file = os.path.join(cf.savepath, cf.weights_test_file)
+        except:
+            cf.weights_test_file = os.path.join(cf.savepath, 'weights.hdf5')
+
 
         # Plot metrics
         if cf.dataset.class_mode == 'segmentation':

--- a/code/models/model.py
+++ b/code/models/model.py
@@ -106,7 +106,7 @@ class One_Net_Model(Model):
         if self.cf.test_model:
             print('\n > Testing the model...')
             # Load best trained model
-            self.model.load_weights(self.cf.weights_file)
+            self.model.load_weights(self.cf.weights_test_file)
 
             # Evaluate model
             start_time = time.time()


### PR DESCRIPTION
We have come across an error when trying transfer learning from the TT100K dataset to the BelgiumTS one. In the config file, we set _load_pretrained = True_  and _weights_file_ to the path of the weights trained in the TT100K dataset. However, in the testing phase, the weights are also loaded from this _weights_file_ variable, so an error is raised as these weights are trained in different datasets with different number of classes (and also, they have not been fine-tuned with the proper dataset). 

The testing could be done in a separate step changing the _weights_file_, but we thought it would be more convenient to add another variable _weights_test_file_ so we can specify whatever path for the testing weights. In order not to change all the config files that don't have this variable, we have set as default the file 'weights.hdf5' in the experiment folder, created after the training.
