### PR TITLE
Fix transfer learning between different datasets and same architecture

### DIFF
--- a/code/config/tt100k_classif.py
+++ b/code/config/tt100k_classif.py
@@ -7,6 +7,7 @@ perc_mb2                     = None            # Percentage of data from the sec
 # Model
 model_name                   = 'vgg16'          # Model to use ['fcn8' | 'lenet' | 'alexNet' | 'vgg16' |  'vgg19' | 'resnet50' | 'InceptionV3']
 freeze_layers_from           = None            # Freeze layers from 0 to this layer during training (Useful for finetunning) [None | 'base_model' | Layer_id]
+different_datasets           = False           # Set to true when loading weights trained for a different dataset
 show_model                   = False           # Show the architecture layers
 load_imageNet                = False           # Load Imagenet weights and normalize following imagenet procedure
 load_pretrained              = False           # Load a pretrained model for doing finetuning

--- a/code/models/model_factory.py
+++ b/code/models/model_factory.py
@@ -27,6 +27,7 @@ from models.fcn8 import build_fcn8
 
 from models.model import One_Net_Model
 
+from keras.models import model_from_json
 
 # Build the model
 class Model_Factory():
@@ -163,7 +164,20 @@ class Model_Factory():
         # Load pretrained weights
         if cf.load_pretrained:
             print('   loading model weights from: ' + cf.weights_file + '...')
-            model.load_weights(cf.weights_file, by_name=True)
+            # If the weights are from different datasets
+            if cf.different_datasets:
+                if cf.freeze_layers_from == 'base_model':
+                    raise TypeError('Please, enter the layer id instead of "base_model"'
+                          ' for the freeze_layers_from config parameter')
+                croppedmodel = model_from_json(model.to_json())
+                # Remove not frozen layers
+                for i in range(len(model.layers[cf.freeze_layers_from:])):
+                    croppedmodel.layers.pop()
+                # Load weights only for the frozen layers
+                croppedmodel.load_weights(cf.weights_file, by_name=True)
+                model.set_weights(croppedmodel.get_weights())
+            else:
+                model.load_weights(cf.weights_file, by_name=True)
 
         # Compile model
         model.compile(loss=loss, metrics=metrics, optimizer=optimizer)


### PR DESCRIPTION
There is an issue when doing transfer learning using two different datasets but the same architecture.
In our case, we train vgg with the TT100K dataset, and then we use these trained weights up to a certain layer for vgg with the BTS dataset.
As the weights are loaded only for the layers with the same name, but all the layers have the same name since it is the same model, an error is raised because of the last classification layer; the number of classes is not the same for both datasets. Therefore, the weights size does not fit.

One workaround is to change the name of the last layer after training, but this is not a good solution, as it has to be done every time in every model.
I propose to load only the weights of the frozen layers in a copy of the model, that only has these layers. And then transfer the weights to our model to train. It avoids the error and works for any model. This option can be chosen with the new config parameter "different_datasets". 