### PR TITLE
LRDecayScheduler callback implemented

### DIFF
--- a/code/callbacks/callbacks.py
+++ b/code/callbacks/callbacks.py
@@ -209,3 +209,33 @@ class Save_results(Callback):
         # Stop data generator
         if enqueuer is not None:
             enqueuer.stop()
+
+
+class LRDecayScheduler(Callback):
+    """
+    Decays the learning rate by the specified decay rate (> 1) at specific epochs, or for each epoch
+    if decay_epochs is None.
+    The updated learning rate is: lr <-- lr / decay_rate
+    """
+    def __init__(self, decay_epochs, decay_rate):
+        super(LRDecayScheduler, self).__init__()
+        self.decay_epochs = decay_epochs
+        self.decay_rate = decay_rate
+
+    def on_epoch_begin(self, epoch, logs=None):
+        current_lr = float(K.get_value(self.model.optimizer.lr))
+        try:
+            new_lr = current_lr / self.decay_rate
+            if (self.decay_epochs is None) or ((epoch+1) in self.decay_epochs):
+                # Decay current learning rate and assign it to the model
+                K.set_value(self.model.optimizer.lr, new_lr)
+                print('    \nLearning rate decayed by a factor of {}: {:.2E} --> {:.2E}\n'.format(
+                    self.decay_rate,
+                    current_lr,
+                    new_lr
+                )
+                )
+        except TypeError:
+            raise ValueError('Decay rate for LRDecayScheduler must be a number.\n'
+                             'Decay epochs for LRDecayScheduler must be a list of numbers.')
+

--- a/code/callbacks/callbacks_factory.py
+++ b/code/callbacks/callbacks_factory.py
@@ -2,7 +2,8 @@ import math
 import os
 
 from keras.callbacks import EarlyStopping, ModelCheckpoint, CSVLogger
-from callbacks import (History_plot, Jacc_new, Save_results)
+
+from callbacks import History_plot, Jacc_new, Save_results, LRDecayScheduler
 
 
 # Create callbacks
@@ -25,7 +26,8 @@ class Callbacks_Factory():
                                 void_label=cf.dataset.void_class,
                                 save_path=cf.savepath,
                                 generator=valid_gen,
-                                epoch_length=int(math.ceil(cf.save_results_nsamples/float(cf.save_results_batch_size))),
+                                epoch_length=int(
+                                    math.ceil(cf.save_results_nsamples / float(cf.save_results_batch_size))),
                                 color_map=cf.dataset.color_map,
                                 classes=cf.dataset.classes,
                                 tag='valid')]
@@ -54,6 +56,11 @@ class Callbacks_Factory():
             cb += [History_plot(cf.dataset.n_classes, cf.savepath,
                                 cf.train_metrics, cf.valid_metrics,
                                 cf.best_metric, cf.best_type, cf.plotHist_verbose)]
+
+        # Decay learning rate at specific epochs
+        if cf.lrDecayScheduler_enabled:
+            print('   Learning rate decay scheduler')
+            cb += [LRDecayScheduler(cf.lrDecayScheduler_epochs, cf.lrDecayScheduler_rate)]
 
         # Save the log
         cb += [CSVLogger(os.path.join(cf.savepath, 'logFile.csv'),

--- a/code/config/camvid_segmentation.py
+++ b/code/config/camvid_segmentation.py
@@ -70,8 +70,13 @@ checkpoint_save_weights_only = True            # Save only weights or also model
 checkpoint_verbose           = 0               # Verbosity of the checkpoint
 
 # Callback plot
-plotHist_enabled             = True           # Enable the Callback
+plotHist_enabled             = True            # Enable the Callback
 plotHist_verbose             = 0               # Verbosity of the callback
+
+# Callback LR decay scheduler
+lrDecayScheduler_enabled     = False           # Enable the Callback
+lrDecayScheduler_epochs      = [5, 10, 20]     # List of epochs were decay is applied or None for all epochs
+lrDecayScheduler_rate        = 2               # Decay rate (new_lr = lr / decay_rate). Usually between 2 and 10.
 
 # Data augmentation for training and normalization
 norm_imageNet_preprocess           = False  # Normalize following imagenet procedure

--- a/code/config/tt100k_classif.py
+++ b/code/config/tt100k_classif.py
@@ -74,6 +74,11 @@ checkpoint_verbose           = 0               # Verbosity of the checkpoint
 plotHist_enabled             = True            # Enable the Callback
 plotHist_verbose             = 0               # Verbosity of the callback
 
+# Callback LR decay scheduler
+lrDecayScheduler_enabled     = False           # Enable the Callback
+lrDecayScheduler_epochs      = [5, 10, 20]     # List of epochs were decay is applied or None for all epochs
+lrDecayScheduler_rate        = 2               # Decay rate (new_lr = lr / decay_rate). Usually between 2 and 10.
+
 # Data augmentation for training and normalization
 norm_imageNet_preprocess           = False     # Normalize following imagenet procedure
 norm_fit_dataset                   = True      # If True it recompute std and mean from images. Either it uses the std and mean set at the dataset config file


### PR DESCRIPTION
Nowadays it is common practice to decay the learning rate when training Deep Neural Networks, as it helps the network converge to the solution.

For that reason we have decided to implement a custom callback that decays the learning rate with the decay factor (lrDecayScheduler_rate) specified by the user at specific epochs (lrDecayScheduler_epochs), also specified by the user. It also allows to decay the learning rate for all epochs if lrDecayScheduler_epochs is set to None.

We have decided to create this pull request so that other groups can benefit from this training procedure, as we have found out it can improve the overall performance of the network. 