### PR TITLE
Config file for transfer learning example

### DIFF
--- a/code/config/belgiumTS_classif_transfer.py
+++ b/code/config/belgiumTS_classif_transfer.py
@@ -11,7 +11,7 @@ show_model                   = False           # Show the architecture layers
 load_imageNet                = False           # Load Imagenet weights and normalize following imagenet procedure
 load_pretrained              = True            # Load a pretrained model for doing finetuning
 weights_file                 = '/path/to/pretrained/weights.hdf5'  # Training weight file name
-weights_test_file			 = 'weights.hdf5'  # Testing weight file name. If this variable doesn't exist, the weights created in the training are used
+weights_test_file            = 'weights.hdf5'  # Testing weight file name. If this variable doesn't exist, the weights created in the training are used
 
 # Parameters
 train_model                  = True            # Train the model

--- a/code/config/belgiumTS_classif_transfer.py
+++ b/code/config/belgiumTS_classif_transfer.py
@@ -1,0 +1,109 @@
+# Dataset
+problem_type                 = 'classification'# ['classification' | 'detection' | 'segmentation']
+dataset_name                 = 'BelgiumTSC'	   # Dataset name
+dataset_name2                = None            # Second dataset name. None if not Domain Adaptation
+perc_mb2                     = None            # Percentage of data from the second dataset in each minibatch
+
+# Model
+model_name                   = 'vgg16'          # Model to use ['fcn8' | 'lenet' | 'alexNet' | 'vgg16' |  'vgg19' | 'resnet50' | 'InceptionV3']
+freeze_layers_from           = 'base_model'    # Freeze layers from 0 to this layer during training (Useful for finetunning) [None | 'base_model' | Layer_id]
+show_model                   = False           # Show the architecture layers
+load_imageNet                = False           # Load Imagenet weights and normalize following imagenet procedure
+load_pretrained              = True            # Load a pretrained model for doing finetuning
+weights_file                 = '/path/to/pretrained/weights.hdf5'  # Training weight file name
+weights_test_file			 = 'weights.hdf5'  # Testing weight file name. If this variable doesn't exist, the weights created in the training are used
+
+# Parameters
+train_model                  = True            # Train the model
+test_model                   = True            # Test the model
+pred_model                   = False           # Predict using the model
+
+# Debug
+debug                        = False           # Use only few images for debuging
+debug_images_train           = 50              # N images for training in debug mode (-1 means all)
+debug_images_valid           = 50              # N images for validation in debug mode (-1 means all)
+debug_images_test            = 50              # N images for testing in debug mode (-1 means all)
+debug_n_epochs               = 2               # N of training epochs in debug mode
+
+# Batch sizes
+batch_size_train             = 10              # Batch size during training
+batch_size_valid             = 30              # Batch size during validation
+batch_size_test              = 30              # Batch size during testing
+crop_size_train              = None            # Crop size during training (Height, Width) or None
+crop_size_valid              = None            # Crop size during validation
+crop_size_test               = None            # Crop size during testing
+resize_train                 = (224, 224)      # Resize the image during training (Height, Width) or None
+resize_valid                 = (224, 224)      # Resize the image during validation
+resize_test                  = (224, 224)      # Resize the image during testing
+
+# Data shuffle
+shuffle_train                = True            # Whether to shuffle the training data
+shuffle_valid                = False           # Whether to shuffle the validation data
+shuffle_test                 = False           # Whether to shuffle the testing data
+seed_train                   = 1924            # Random seed for the training shuffle
+seed_valid                   = 1924            # Random seed for the validation shuffle
+seed_test                    = 1924            # Random seed for the testing shuffle
+
+# Training parameters
+optimizer                    = 'rmsprop'       # Optimizer
+learning_rate                = 0.0001          # Training learning rate
+weight_decay                 = 0.              # Weight decay or L2 parameter norm penalty
+n_epochs                     = 30              # Number of epochs during training
+
+# Callback save results
+save_results_enabled         = False           # Enable the Callback
+save_results_nsamples        = 5               # Number of samples to save
+save_results_batch_size      = 5               # Size of the batch
+save_results_n_legend_rows   = 1               # Number of rows when showwing the legend
+
+# Callback early stoping
+earlyStopping_enabled        = True            # Enable the Callback
+earlyStopping_monitor        = 'acc'           # Metric to monitor
+earlyStopping_mode           = 'max'           # Mode ['max' | 'min']
+earlyStopping_patience       = 100             # Max patience for the early stopping
+earlyStopping_verbose        = 0               # Verbosity of the early stopping
+
+# Callback model check point
+checkpoint_enabled           = True            # Enable the Callback
+checkpoint_monitor           = 'acc'           # Metric to monitor
+checkpoint_mode              = 'max'           # Mode ['max' | 'min']
+checkpoint_save_best_only    = True            # Save best or last model
+checkpoint_save_weights_only = True            # Save only weights or also model
+checkpoint_verbose           = 0               # Verbosity of the checkpoint
+
+# Callback plot
+plotHist_enabled             = True            # Enable the Callback
+plotHist_verbose             = 0               # Verbosity of the callback
+
+# Callback LR decay scheduler
+lrDecayScheduler_enabled     = False           # Enable the Callback
+lrDecayScheduler_epochs      = [5, 10, 20]     # List of epochs were decay is applied or None for all epochs
+lrDecayScheduler_rate        = 2               # Decay rate (new_lr = lr / decay_rate). Usually between 2 and 10.
+
+# Data augmentation for training and normalization
+norm_imageNet_preprocess           = False     # Normalize following imagenet procedure
+norm_fit_dataset                   = True      # If True it recompute std and mean from images. Either it uses the std and mean set at the dataset config file
+norm_rescale                       = 1/255.    # Scalar to divide and set range 0-1
+norm_featurewise_center            = False     # Substract mean - dataset
+norm_featurewise_std_normalization = False     # Divide std - dataset
+norm_samplewise_center             = False     # Substract mean - sample
+norm_samplewise_std_normalization  = False     # Divide std - sample
+norm_gcn                           = False     # Global contrast normalization
+norm_zca_whitening                 = False     # Apply ZCA whitening
+cb_weights_method                  = None      # Label weight balance [None | 'median_freq_cost' | 'rare_freq_cost']
+
+# Data augmentation for training
+da_rotation_range                  = 0          # Rnd rotation degrees 0-180
+da_width_shift_range               = 0.0        # Rnd horizontal shift
+da_height_shift_range              = 0.0        # Rnd vertical shift
+da_shear_range                     = 0.0        # Shear in radians
+da_zoom_range                      = 0.0        # Zoom
+da_channel_shift_range             = 0.         # Channecf.l shifts
+da_fill_mode                       = 'constant' # Fill mode
+da_cval                            = 0.         # Void image value
+da_horizontal_flip                 = False      # Rnd horizontal flip
+da_vertical_flip                   = False      # Rnd vertical flip
+da_spline_warp                     = False      # Enable elastic deformation
+da_warp_sigma                      = 10         # Elastic deformation sigma
+da_warp_grid_size                  = 3          # Elastic deformation gridSize
+da_save_to_dir                     = False      # Save the images for debuging


### PR DESCRIPTION
As asked in #9, I provide a config file example for doing transfer learning to another dataset. I took the tt100k_classif.py as the base and changed:
* dataset_name = 'BelgiumTSC'
* freeze_layers_from = 'base_model' (just because we are supposed to be finetuning on a similar dataset, but it doesn't matter) 
* load_pretrained = True (as we are loading some pretrained weights, in TT100K for example)
* weights_file = '/path/to/pretrained/weights.hdf5' (I didn't put a real path because everyone will have a different one)
* weights_test_file = 'weights.hdf5' (this variable is actually not needed, if it doesn't exist it will load the  trained weights in this experiment for the testing, which are found in the experiment's folder with the name 'weights.hdf5'. I added it in case we wanted to do a test with some other weights at some point)