### PR TITLE
plot history with two axis

### DIFF
--- a/code/tools/plot_history.py
+++ b/code/tools/plot_history.py
@@ -15,6 +15,9 @@ def plot_history(hist, save_path, n_classes,
 
     # Create string to print
     str = ''
+    
+    # Colors (we assume there are no more than 7 metrics):
+    colors = ['r', 'g', 'k', 'm', 'c', 'y', 'w']
 
     # Find the best epoch
     if best_type=='max':
@@ -24,32 +27,54 @@ def plot_history(hist, save_path, n_classes,
     else:
         raise ValueError('Unknown best type. It should be max or min')
     str += '   Best epoch: {}\n'.format(best_index)
+    
+    # Initialize figure:
+    # Axis 1 will be for metrics, and axis 2 for losses.
+    fig, ax1 = plt.subplots()
+    ax2 = ax1.twinx()
 
     # Check the training metrics
+    idx = -1 # index for colors
     for metric in train_metrics:
         best_value = hist[metric][best_index]
         str += '   - {}: {}\n'.format(metric, best_value)
-        plt.plot(hist[metric], label='{} ({:.3f})'.format(metric, best_value))
+        if metric == 'loss':
+            ax2.plot(hist[metric], 'b-', label='{} ({:.3f})'.format(metric, best_value))
+        else:
+            idx += 1
+            ax1.plot(hist[metric], colors[idx] + '-', label='{} ({:.3f})'.format(metric, best_value))
 
-    # Check the training metrics
+    # Check the validation metrics
+    idx = -1 # index for colors
     for metric in valid_metrics:
         best_value = hist[metric][best_index]
         str += '   - {}: {}\n'.format(metric, best_value)
-        plt.plot(hist[metric], label='{} ({:.3f})'.format(metric, best_value))
+        if metric == 'val_loss':
+            ax2.plot(hist[metric], 'b--', label='{} ({:.3f})'.format(metric, best_value))
+        else:
+            idx += 1
+            ax1.plot(hist[metric], colors[idx] + '--', label='{} ({:.3f})'.format(metric, best_value))
 
     # Print the result
     if verbose:
         print(str)
+        
+    ax1.set_ylim(0,1)
 
     # Add title
     plt.title('Model training history')
 
     # Add axis labels
-    plt.ylabel('Metric')
-    plt.xlabel('Epoch')
+    ax1.set_ylabel('Metric')
+    ax2.set_ylabel('Loss')
+    ax1.set_xlabel('Epoch')
+    
+    # ??
+    fig.tight_layout()
 
     # Add legend
-    plt.legend(loc='upper left')
+    ax1.legend(loc='upper left')
+    ax2.legend(loc='upper right')
 
     # Save fig
     plt.savefig(os.path.join(save_path, 'plot1.png'))


### PR DESCRIPTION
I propose to change the plotting of the loss and the metrics. I don't like the fact that both quantities go in the same axis, when they have very different scales. Actually, usually it was impossible to see anything about the accuracy (or recall or iou), because it was masked out by the range of the loss.

In this modification there is an axis for the metrics (assuming they will be between 0 and 1, as is the case for accuracy, recall or iou), and another axis for the loss. Training curves are solid, and validation ones are dashed lines. The color is the same for each magnitude, regardless whether it is for training or validation. An example can be seen below.

![plot1](https://cloud.githubusercontent.com/assets/22598615/24056693/ffd58b34-0b44-11e7-84c4-5d9a165d7cb5.png)
